### PR TITLE
Fix: Ensure sound buttons fit on small screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -47,13 +47,13 @@ canvas {
 /* 4) Зона кнопок — три ряда */
 #bottom {
   flex-direction: column;
-  gap: 40px;
-  padding: 40px;
+  gap: 4vmin;
+  padding: 4vmin;
 }
 .row {
   flex: 1;
   display: flex;
-  gap: 40px;
+  gap: 4vmin;
 }
 
 /* 5) Кнопки/иконки внутри ряда */


### PR DESCRIPTION
The sound buttons in the bottom bar were partially extending beyond the screen on smaller devices like Android phones.

This was caused by fixed padding and gap values in `css/styles.css` for the `#bottom` container and `.row` elements.

The fix replaces the static `40px` values for padding and gaps with a responsive `4vmin` unit. This allows the spacing to adapt to the viewport size, preventing overflow.

Manual analysis confirmed that with `4vmin`, the buttons and their spacing correctly adjust and remain within the screen boundaries on common mobile screen widths (320px, 360px, 375px, 412px), while `flex: 1` and `min-width: 0` on the button elements ensure they resize appropriately.